### PR TITLE
change the separator in the python submitter on the response parquet

### DIFF
--- a/perf-system/submitter/submit.py
+++ b/perf-system/submitter/submit.py
@@ -84,11 +84,11 @@ def write_response(resp, df_responses, end_time, i, last_index):
         resp.url.scheme
         + str(resp.version.major)
         + str(resp.version.minor)
-        + "$"
+        + " "
         + str(resp.status)
-        + "$"
+        + " "
         + resp.reason
-        + "$"
+        + "\n"
         + str(resp.raw_headers),
     ]
 


### PR DESCRIPTION
After the C++ submitter, I used different notation to post the responses from server to the parquet file, which in python submitter was not changed. It should be now fixed.